### PR TITLE
fix(core): missing generic interface passthrough in find method

### DIFF
--- a/packages/core/classes/manager/entity-manager.ts
+++ b/packages/core/classes/manager/entity-manager.ts
@@ -271,7 +271,7 @@ export class EntityManager extends BaseManager {
     return {
       ...response,
       items: response.items.map(item =>
-        this._entityTransformer.fromDynamoEntity(entityClass, item)
+        this._entityTransformer.fromDynamoEntity<Entity>(entityClass, item)
       ),
     };
   }


### PR DESCRIPTION
This was caused by generic interface placeholder `<Entity>` not being passed through find method.

closes #8  