### PR TITLE
24 add support for loading explicite creds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "KSUID",
+    "Metadatas",
     "bazel",
     "commitlint",
     "dynamodb",

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Index
+
+Document index that covers, list of pages available
+
+- [How it works](./how-it-works.md)
+- [Step by step guide](./guide.md)
+- [Entity inheritance](./entity-inheritance.md)
+- [Working with multiple connections](./multiple-connection.md)

--- a/docs/multiple-connection.md
+++ b/docs/multiple-connection.md
@@ -1,0 +1,49 @@
+# Working with multiple connections
+
+Let's assume that we have a two different tables running two different workloads, one is for `app1` workload and other is for `app2` workload. In order to be able to interact with these two tables, we have two user with different permissions, `app1User` and `app2User`.
+
+Now, we have a service that needs to be able to work with both tables in that are registered in separate connections. Working with different connections using different credentials, will look something like this.
+
+First we create two separate connections both using different credentials
+
+```Typescript
+// connection for app1
+createConnection({
+  name: 'app1'
+  table: app1Table,
+  entities: [...entities],
+  documentClient: {
+    credentials: {
+      accessKeyId: process.env.APP_1_ACCESS_KEY_ID,
+      secretAccessKey: process.env.APP_1_SECRET_ACCESS_KEY
+    }
+  }
+});
+
+// connection for app2
+createConnection({
+  name: 'app2'
+  table: app1Table,
+  entities: [...entities],
+  documentClient: {
+    credentials: {
+      accessKeyId: process.env.APP_2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.APP_2_SECRET_ACCESS_KEY
+    }
+  }
+});
+```
+
+Now we can use multiple connections to different actions, that are using completely different credentials,
+
+```Typescript
+// update record in both table in different connections
+
+// create user in connection 1
+getEntityManager('app1').create(User, {...})
+
+// update record in connection2
+getEntityManager('app2').create(Record, {...})
+```
+
+TypeDORM makes it super easy to configure multiple connections with different connection options.

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -16,6 +16,7 @@ export * from './require-at-least-one-type';
 export * from './require-only-one-type';
 export * from './scalar-type';
 export * from './update-attributes-type';
+export * from './replace-type';
 
 // classes
 export * from './table';

--- a/packages/common/replace-type.ts
+++ b/packages/common/replace-type.ts
@@ -1,0 +1,1 @@
+export type Replace<T, K extends keyof T, R> = Omit<T, K> & R;

--- a/packages/core/classes/connection/connection-options.ts
+++ b/packages/core/classes/connection/connection-options.ts
@@ -1,8 +1,29 @@
 import {EntityTarget, Table} from '@typedorm/common';
+import {DocumentClient} from 'aws-sdk/clients/dynamodb';
 
+/**
+ * @param table - Global table to use for all entities, entity scoped table takes precedence over this
+ * @param name - Connection name
+ * @param dynamoQueryItemsImplicitLimit - Implicit limit to apply when querying items, this will be overridden by explicit limit
+ * @param entities - List of entity classes or global pattern string matching all entities
+ * @param documentClient - Document client to use for this connection
+ */
 export interface ConnectionOptions {
+  /**
+   * @default - none
+   */
   table?: Table;
+  /**
+   * @default - 'default'
+   */
   name?: string;
+  /**
+   * @default 3000
+   */
   dynamoQueryItemsImplicitLimit?: number;
   entities: EntityTarget<any>[] | string;
+  /**
+   * @default - new document client instance with default config will be instantiated
+   */
+  documentClient?: DocumentClient;
 }

--- a/packages/core/classes/connection/connection.ts
+++ b/packages/core/classes/connection/connection.ts
@@ -3,6 +3,7 @@ import {
   EntityTarget,
   Table,
 } from '@typedorm/common';
+import {DocumentClient} from 'aws-sdk/clients/dynamodb';
 import {EntityManager} from '../manager/entity-manager';
 import {TransactionManager} from '../manager/transaction-manager';
 import {AttributeMetadata} from '../metadata/attribute-metadata';
@@ -20,6 +21,7 @@ export class Connection {
   readonly entityManager: EntityManager;
   readonly transactionManger: TransactionManager;
   readonly defaultConfig: {queryItemsImplicitLimit: number};
+  readonly documentClient: DocumentClient;
 
   private _entityMetadatas: Map<string, EntityMetadata>;
   private isConnected: boolean;
@@ -31,12 +33,18 @@ export class Connection {
     }
     this.name = name;
     this.entityManager = new EntityManager(this);
-    this.transactionManger = new TransactionManager();
+    this.transactionManger = new TransactionManager(this);
     this.defaultConfig = {
       queryItemsImplicitLimit:
         options.dynamoQueryItemsImplicitLimit ??
         DYNAMO_QUERY_ITEMS_IMPLICIT_LIMIT,
     };
+
+    if (options.documentClient) {
+      this.documentClient = options.documentClient;
+    } else {
+      this.documentClient = new DocumentClient();
+    }
     /**
      * This makes sure that we only ever build entity metadatas once per connection
      */

--- a/packages/core/classes/manager/base-manager.ts
+++ b/packages/core/classes/manager/base-manager.ts
@@ -1,8 +1,0 @@
-import {DynamoDB} from 'aws-sdk';
-
-export abstract class BaseManager {
-  protected _dc: DynamoDB.DocumentClient;
-  constructor() {
-    this._dc = new DynamoDB.DocumentClient();
-  }
-}

--- a/packages/core/classes/manager/transaction-manager.ts
+++ b/packages/core/classes/manager/transaction-manager.ts
@@ -1,15 +1,13 @@
 import {DocumentClient} from 'aws-sdk/clients/dynamodb';
 import {TRANSACTION_WRITE_ITEMS_LIMIT} from '@typedorm/common';
 import {WriteTransaction} from '../transaction/write-transaction';
-import {BaseManager} from './base-manager';
+import {Connection} from '../connection/connection';
 
 /**
  * Performs transactions using document client's writeTransaction
  */
-export class TransactionManager extends BaseManager {
-  constructor() {
-    super();
-  }
+export class TransactionManager {
+  constructor(private connection: Connection) {}
 
   async write(transaction: WriteTransaction) {
     if (transaction.items.length > TRANSACTION_WRITE_ITEMS_LIMIT) {
@@ -25,7 +23,9 @@ export class TransactionManager extends BaseManager {
     // FIXME: current promise implementation of document client transact write does not provide a way
     // the transaction was failed, as a work around we do following.
     // refer to this issue for more details https://github.com/aws/aws-sdk-js/issues/2464
-    const transactionRequest = this._dc.transactWrite(transactionInput);
+    const transactionRequest = this.connection.documentClient.transactWrite(
+      transactionInput
+    );
 
     let cancellationReasons: any[];
     transactionRequest.on('extractError', response => {

--- a/packages/testing/BUILD
+++ b/packages/testing/BUILD
@@ -5,7 +5,10 @@ setup_ts_build(
     name = "library",
     module_name = "@typedorm/testing",
     deps = [
-        "//packages/core:library"
+        "//packages/core:library",
+        "//packages/common:library",
+        "@npm//aws-sdk",
+        "@npm//@types/jest"
     ],
     visibility = ["//packages:__subpackages__"]
 

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -1,9 +1,21 @@
+import {Replace} from '@typedorm/common';
 import {createConnection, ConnectionOptions} from '@typedorm/core';
 import {ConnectionManager} from '@typedorm/core/classes/connection/connection-manager';
 import {Container} from '@typedorm/core/classes/container';
+import {DynamoDB} from 'aws-sdk';
 
-export function createTestConnection(connectionOptions: ConnectionOptions) {
-  return createConnection(connectionOptions);
+export function createTestConnection(
+  connectionOptions: Replace<
+    ConnectionOptions,
+    'documentClient',
+    {
+      documentClient?: {
+        [key in keyof DynamoDB.DocumentClient]?: jest.SpyInstance;
+      };
+    }
+  >
+) {
+  return createConnection(connectionOptions as ConnectionOptions);
 }
 
 export function resetTestConnection() {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -11,7 +11,8 @@
   "peerDependencies": {
     "@typedorm/common": "0.0.0-PLACEHOLDER",
     "@typedorm/core": "0.0.0-PLACEHOLDER",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "aws-sdk": "^2.799.0"
   },
   "publishConfig": {
     "tag": "TAG-PLACEHOLDER",


### PR DESCRIPTION
# Changes

- add support for custom document client to use for a connection
- add support for providing mock `documentClient` when creating test connections
- add docs

closes #24 