### PR TITLE
fix(core): add option to use enum on property in key schema

### DIFF
--- a/packages/common/decorators/__test__/attribute.decorator.spec.ts
+++ b/packages/common/decorators/__test__/attribute.decorator.spec.ts
@@ -30,3 +30,33 @@ test('adds raw metadata', () => {
     },
   ]);
 });
+
+/**
+ * Issue #29
+ */
+test('adds raw metadata for enum property', () => {
+  enum ROLE {
+    ADMIN = 'admin',
+    USER = 'user',
+  }
+  @Entity({
+    name: 'user',
+    primaryKey: {
+      partitionKey: 'USER#{{role}}',
+    },
+  })
+  class User {
+    @Attribute({
+      isEnum: true,
+    })
+    role: ROLE;
+  }
+  expect(
+    MetadataManager.metadataStorage.getRawAttributesForEntity(User)
+  ).toEqual([
+    {
+      name: 'role',
+      type: 'String',
+    },
+  ]);
+});

--- a/packages/common/decorators/attribute.decorator.ts
+++ b/packages/common/decorators/attribute.decorator.ts
@@ -4,19 +4,30 @@ import {AttributeRawMetadataOptions} from '../metadata-storage';
 
 export interface AttributeOptions {
   /**
-   * item will be managed using transaction to ensure it's consistency
+   * Item will be managed using transaction to ensure it's consistency
    * @default false
    */
-  unique: boolean;
+  unique?: boolean;
+  /**
+   * Mark property as enum
+   * @required when property of type enum is referenced in key
+   * @default false
+   */
+  isEnum?: boolean;
 }
 
 export function Attribute(options?: AttributeOptions): PropertyDecorator {
   return (target, propertyKey): void => {
-    const type = Reflect.getMetadata('design:type', target, propertyKey);
+    let type = Reflect.getMetadata('design:type', target, propertyKey).name;
+
+    if (options?.isEnum) {
+      // default to "String" when attribute is marked as enum
+      type = 'String';
+    }
 
     const attributeProps = {
       name: propertyKey.toString(),
-      type: type.name,
+      type,
       unique: options?.unique,
     } as AttributeRawMetadataOptions;
 


### PR DESCRIPTION
- allow using property of type enum when referencing it in key schema

closes #29 