### PR TITLE
fix(core): skip non entity classes when building metadata

### DIFF
--- a/packages/common/src/metadata/metadata-storage.ts
+++ b/packages/common/src/metadata/metadata-storage.ts
@@ -50,6 +50,10 @@ export class MetadataStorage {
     this._attributes = new Map();
   }
 
+  hasKnownEntityByName(name: string) {
+    return this._entities.has(name);
+  }
+
   getRawAttributesForEntity<Entity>(entityClass: EntityTarget<Entity>) {
     const attributes = this._attributes.get(entityClass.name)?.values();
 

--- a/packages/core/__mocks__/non-decorated-entity.ts
+++ b/packages/core/__mocks__/non-decorated-entity.ts
@@ -1,0 +1,6 @@
+/**
+ * I am a simple class, that is placed with entities
+ */
+export class NonDecoratedEntity {
+  message: string;
+}

--- a/packages/core/src/classes/connection/connection-metadata-builder.ts
+++ b/packages/core/src/classes/connection/connection-metadata-builder.ts
@@ -3,17 +3,23 @@ import path from 'path';
 import {EntityTarget} from '@typedorm/common';
 import {Connection} from './connection';
 import {EntityMetadataBuilder} from './entity-metadata-builder';
+import {MetadataManager} from '@typedorm/common/metadata-manager';
 
 export class ConnectionMetadataBuilder {
   constructor(private connection: Connection) {}
 
   buildEntityMetadatas(entities: EntityTarget<any>[] | string) {
-    let entitiesToBuild = [] as Function[];
+    let possibleEntitiesToBuild = [] as Function[];
     if (typeof entities === 'string') {
-      entitiesToBuild = [...this.loadEntitiesFromDirs(entities)];
+      possibleEntitiesToBuild = [...this.loadEntitiesFromDirs(entities)];
     } else {
-      entitiesToBuild = [...entities];
+      possibleEntitiesToBuild = [...entities];
     }
+
+    // filter all entities that are not marked with `@Entity` decorator
+    const entitiesToBuild = possibleEntitiesToBuild.filter(entity =>
+      MetadataManager.metadataStorage.hasKnownEntityByName(entity.name)
+    );
 
     return new EntityMetadataBuilder(this.connection).build(entitiesToBuild);
   }

--- a/packages/core/src/classes/connection/connection-metadata-builder.ts
+++ b/packages/core/src/classes/connection/connection-metadata-builder.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import {EntityTarget} from '@typedorm/common';
 import {Connection} from './connection';
 import {EntityMetadataBuilder} from './entity-metadata-builder';
-import {MetadataManager} from '@typedorm/common/metadata-manager';
+import {MetadataManager} from '@typedorm/common';
 
 export class ConnectionMetadataBuilder {
   constructor(private connection: Connection) {}


### PR DESCRIPTION
When using glob matching pattern to find entities to build, if there are classes matched with non `@Entity` decorator, filter them while building metadata to avoid getting build error.

closes #30 