### PR TITLE
fix(core): return undefined instead of empty object

### DIFF
--- a/packages/core/src/classes/manager/entity-manager.ts
+++ b/packages/core/src/classes/manager/entity-manager.ts
@@ -150,10 +150,16 @@ export class EntityManager {
       .get(dynamoGetItem)
       .promise();
 
+    // return early when not found
+    if (!response.Item) {
+      return;
+    }
+
     const entity = this._entityTransformer.fromDynamoEntity<Entity>(
       entityClass,
-      response.Item ?? {}
+      response.Item
     );
+
     return entity;
   }
 


### PR DESCRIPTION
# Changes
- `EntityManage.findOne` will now return `undefined` when the item with a given primary key does not eixst.

closes #110 