### PR TITLE
Improve lazy entity updates handler

### DIFF
--- a/packages/core/src/classes/manager/batch-manager.ts
+++ b/packages/core/src/classes/manager/batch-manager.ts
@@ -136,16 +136,6 @@ export class BatchManager {
               }
             );
 
-            if (!existingItem) {
-              throw new Error(
-                `Failed to batch write item ${
-                  transformedInput.entityClass.name
-                }. Could not find entity with primary key "${JSON.stringify(
-                  transformedInput.primaryKeyAttributes
-                )}"`
-              );
-            }
-
             const deleteTransactionItemList = transformedInput.lazyLoadTransactionWriteItems(
               existingItem
             );

--- a/packages/core/src/classes/manager/entity-manager.ts
+++ b/packages/core/src/classes/manager/entity-manager.ts
@@ -427,14 +427,6 @@ export class EntityManager {
       metadataOptions
     );
 
-    if (!existingItem) {
-      throw new Error(
-        `Failed to update entity, could not find entity with primary key "${JSON.stringify(
-          primaryKeyAttributes
-        )}"`
-      );
-    }
-
     const updateItemList = dynamoUpdateItem.lazyLoadTransactionWriteItems(
       existingItem
     );
@@ -499,14 +491,6 @@ export class EntityManager {
       undefined,
       metadataOptions
     );
-
-    if (!existingItem) {
-      throw new Error(
-        `Failed to update entity, could not find entity with primary key "${JSON.stringify(
-          primaryKeyAttributes
-        )}"`
-      );
-    }
 
     const deleteItemList = dynamoDeleteItem.lazyLoadTransactionWriteItems(
       existingItem

--- a/packages/core/src/classes/manager/transaction-manager.ts
+++ b/packages/core/src/classes/manager/transaction-manager.ts
@@ -62,10 +62,12 @@ export class TransactionManager {
               returnConsumedCapacity: metadataOptions?.returnConsumedCapacity,
             }
           );
+
           return item.lazyLoadTransactionWriteItems(existingItem);
         })
       )
     ).flat();
+
     const itemsToWriteInTransaction = [
       ...transactionItemList,
       ...lazyTransactionItems,

--- a/packages/core/src/classes/transformer/document-client-request-transformer.ts
+++ b/packages/core/src/classes/transformer/document-client-request-transformer.ts
@@ -904,7 +904,7 @@ export class DocumentClientRequestTransformer extends BaseTransformer {
           ];
 
           // if unique attribute previously existed, remove it as part of the same transaction
-          if (previousItemBody[attr.name]) {
+          if (previousItemBody && previousItemBody[attr.name]) {
             uniqueAttributeWriteItems.push({
               Delete: {
                 TableName: table.name,
@@ -960,8 +960,9 @@ export class DocumentClientRequestTransformer extends BaseTransformer {
     metadataOptions?: MetadataOptions
   ) {
     return (existingItemBody: any) => {
-      const uniqueAttributeInputs: DynamoDB.DocumentClient.TransactWriteItemList = uniqueAttributesToRemove.map(
-        attr => {
+      let uniqueAttributeInputs: DynamoDB.DocumentClient.TransactWriteItemList = [];
+      if (existingItemBody) {
+        uniqueAttributeInputs = uniqueAttributesToRemove.map(attr => {
           return {
             Delete: {
               TableName: table.name,
@@ -974,8 +975,8 @@ export class DocumentClientRequestTransformer extends BaseTransformer {
               },
             },
           };
-        }
-      );
+        });
+      }
 
       const deleteTransactionItems = [
         {


### PR DESCRIPTION
# Changes
- fix entity manager implementation for `update` and `delete`
  - if tried to modify an item with unique attributes, and if there was no existing item with a matching primary key, request should not fail

closes #106 