### PR TITLE
fix(core): correctly handle entities with custom constructor

### DIFF
--- a/packages/core/__mocks__/user-custom-constructor.ts
+++ b/packages/core/__mocks__/user-custom-constructor.ts
@@ -1,0 +1,26 @@
+import {Attribute, Entity} from '@typedorm/common';
+import {table} from './table';
+
+export interface UserPrimaryKey {
+  id: string;
+}
+
+@Entity({
+  table,
+  name: 'user-custom-constructor',
+  primaryKey: {
+    partitionKey: 'USER#{{id}}',
+    sortKey: 'USER#{{id}}',
+  },
+})
+export class UserCustomConstructor implements UserPrimaryKey {
+  @Attribute()
+  id: string;
+
+  @Attribute()
+  name: string;
+
+  constructor({name}: Partial<UserCustomConstructor>) {
+    this.name = name!;
+  }
+}

--- a/packages/core/src/classes/connection/__test__/connection-metadata-builder.spec.ts
+++ b/packages/core/src/classes/connection/__test__/connection-metadata-builder.spec.ts
@@ -41,7 +41,7 @@ test('builds entity metadata with path match', () => {
     path.resolve(__dirname, '../../../../__mocks__/**/*.ts')
   );
 
-  expect(entities.length).toEqual(8);
+  expect(entities.length).toEqual(9);
 });
 
 test('throws when trying to register duplicated entities', () => {

--- a/packages/core/src/classes/transformer/__test__/entity-transformer.spec.ts
+++ b/packages/core/src/classes/transformer/__test__/entity-transformer.spec.ts
@@ -18,6 +18,7 @@ import {CATEGORY, Photo} from '@typedorm/core/__mocks__/photo';
 // Moment is only being used here to display the usage of @transform utility
 // eslint-disable-next-line node/no-extraneous-import
 import moment from 'moment';
+import {UserCustomConstructor} from '@typedorm/core/__mocks__/user-custom-constructor';
 
 jest.mock('uuid', () => ({
   v4: () => 'c0ac5395-ba7c-41bf-bbc3-09a6087bcca2',
@@ -34,6 +35,7 @@ beforeEach(() => {
       UserSparseIndexes,
       UserAttrAlias,
       Photo,
+      UserCustomConstructor,
     ],
   });
   transformer = new EntityTransformer(connection);
@@ -61,6 +63,26 @@ test('transforms dynamo entity to entity model', () => {
     id: '1',
     name: 'Me',
     status: 'active',
+  });
+});
+
+/**
+ * Issue: #134
+ */
+test('transforms dynamo entity to entity model with custom constructor', () => {
+  const dynamoEntity = {
+    PK: 'USER#1',
+    SK: 'USER#1',
+    id: '1',
+    name: 'Me',
+  };
+  const transformed = transformer.fromDynamoEntity(
+    UserCustomConstructor,
+    dynamoEntity
+  );
+  expect(transformed).toEqual({
+    id: '1',
+    name: 'Me',
   });
 });
 

--- a/packages/core/src/classes/transformer/entity-transformer.ts
+++ b/packages/core/src/classes/transformer/entity-transformer.ts
@@ -1,6 +1,6 @@
 import {DynamoEntity, EntityTarget, TRANSFORM_TYPE} from '@typedorm/common';
 import {DocumentClient} from 'aws-sdk/clients/dynamodb';
-import {ClassConstructor, plainToClass} from 'class-transformer';
+import {plainToClassFromExist} from 'class-transformer';
 import {unParseKey} from '../../helpers/unparse-key';
 import {Connection} from '../connection/connection';
 import {BaseTransformer, MetadataOptions} from './base-transformer';
@@ -67,8 +67,10 @@ export class EntityTransformer extends BaseTransformer {
       {} as Object
     );
 
-    const transformedEntity = plainToClass(
-      entityClass as ClassConstructor<Entity>,
+    // get reflected constructor to avoid initialization issues with custom constructor
+    const reflectedConstructor = Reflect.construct(Object, [], entityClass);
+    const transformedEntity = plainToClassFromExist(
+      reflectedConstructor,
       plainEntityAttributes
     );
 


### PR DESCRIPTION
Fixes an issue where if an entity contains a custom constructor it fails to deserialize.

closes #134 