### PR TITLE
fix(core): allow `@Entity` declarations with no attributes

### DIFF
--- a/packages/common/src/metadata/metadata-storage.ts
+++ b/packages/common/src/metadata/metadata-storage.ts
@@ -79,8 +79,10 @@ export class MetadataStorage {
     const attributes = this._attributes.get(entityClass)?.values();
 
     if (!attributes) {
-      throw new Error(`No entity with name "${entityClass.name}" could be resolved, 
-      make sure they have been declared at the connection creation time.`);
+      // it is possible that entity might not have any attributes referenced such cases are
+      // when inherited entity contains all the attribute declarations and derived ones only defines schema for it
+      // Thus, instead of throwing an error, simply return [] list to continue processing other attributes
+      return [];
     }
     return Array.from(attributes);
   }

--- a/packages/core/src/classes/connection/__test__/entity-metadata-builder.spec.ts
+++ b/packages/core/src/classes/connection/__test__/entity-metadata-builder.spec.ts
@@ -229,6 +229,38 @@ test('builds metadata of derived entity with multiple levels of inheritance', ()
   ]);
 });
 
+/**
+ * Issue #138
+ */
+test('builds metadata of derived entity where derived entity does not have any explicit metadata defined', () => {
+  abstract class BaseEntity {
+    @Attribute()
+    id: string;
+  }
+
+  @Entity({
+    name: 'SubEntity',
+    primaryKey: {
+      partitionKey: 'SubEntity#{{id}}',
+      sortKey: 'SubEntity#{{id}}',
+    },
+  })
+  class SubEntity extends BaseEntity {
+    // no attributes
+  }
+
+  const [entityMetadata] = metadataBuilder.build([SubEntity]);
+
+  expect(entityMetadata.attributes).toEqual([
+    {
+      entityClass: SubEntity,
+      name: 'id',
+      table,
+      type: 'String',
+    },
+  ]);
+});
+
 test('builds entity metadata with global table config', () => {
   const globalTable = new Table({
     name: 'GlobalTable',


### PR DESCRIPTION
Fixes an issue where if trying to define an `@Entity` with no `@Attributes` it fails to build.


closes #138

