### PR TITLE
[157] Fixed Invalid set type error on set types

### DIFF
--- a/__test__/github-issues/157/issue-157.spec.ts
+++ b/__test__/github-issues/157/issue-157.spec.ts
@@ -1,0 +1,71 @@
+// assuming there is a EMAIL_INDEX loaded before anything else
+process.env.EMAIL_INDEX = 'email-index-v2';
+
+import {testTable} from './test-table';
+import {EntityManager} from '@typedorm/core';
+import {createTestConnection, resetTestConnection} from '@typedorm/testing';
+import EntityData from './test-entity';
+let entityManager: EntityManager;
+
+const dcMock = {
+  query: jest.fn(),
+};
+beforeEach(() => {
+  const connection = createTestConnection({
+    entities: [EntityData],
+    table: testTable,
+    documentClient: dcMock,
+  });
+  entityManager = new EntityManager(connection);
+});
+
+afterEach(() => {
+  resetTestConnection();
+});
+
+test('correctly queries matching items', async () => {
+  dcMock.query.mockReturnValue({
+    promise: () => ({
+      Items: [
+        {
+          SK: 'root',
+          stringSet: ['test'],
+          email: 'test-entity@gmail.com',
+          PK: 'entity#12345678',
+          name: 'ABCD',
+        },
+      ],
+    }),
+  });
+
+  const response = await entityManager.find(
+    EntityData,
+    'test-entity@gmail.com',
+    {
+      queryIndex: process.env.EMAIL_INDEX!,
+      limit: 1,
+    }
+  );
+
+  expect(dcMock.query).toHaveBeenCalledWith({
+    ExpressionAttributeNames: {
+      '#KY_CE_email': 'email',
+    },
+    ExpressionAttributeValues: {
+      ':KY_CE_email': 'test-entity@gmail.com',
+    },
+    IndexName: 'email-index-v2',
+    KeyConditionExpression: '#KY_CE_email = :KY_CE_email',
+    Limit: 1,
+    ScanIndexForward: true,
+    TableName: 'user-v2',
+  });
+
+  const entityData = new EntityData();
+  entityData.name = 'ABCD';
+  (entityData as any).stringSet = ['test'];
+
+  expect(response).toEqual({
+    items: [entityData],
+  });
+});

--- a/__test__/github-issues/157/issue-157.spec.ts
+++ b/__test__/github-issues/157/issue-157.spec.ts
@@ -5,6 +5,7 @@ import {testTable} from './test-table';
 import {EntityManager} from '@typedorm/core';
 import {createTestConnection, resetTestConnection} from '@typedorm/testing';
 import EntityData from './test-entity';
+import {DocumentClient} from 'aws-sdk/clients/dynamodb';
 let entityManager: EntityManager;
 
 const dcMock = {
@@ -23,13 +24,17 @@ afterEach(() => {
   resetTestConnection();
 });
 
-test('correctly queries matching items', async () => {
+test('correctly queries matching items when values for set type is not a native js type ', async () => {
   dcMock.query.mockReturnValue({
     promise: () => ({
       Items: [
         {
           SK: 'root',
-          stringSet: ['test'],
+          // Here string set contains a non-js-native type `Set()`
+          // This type is emitted by document client in cases where dynamodb item was created outside the js ecosystem
+          // i.e DynamoDB it self supports `StringSet` type but since js doesn't have a `StringSet` as a native type,
+          // DocumentClient wraps it as a custom `Set` type
+          stringSet: new DocumentClient().createSet(['test']),
           email: 'test-entity@gmail.com',
           PK: 'entity#12345678',
           name: 'ABCD',

--- a/__test__/github-issues/157/test-entity.ts
+++ b/__test__/github-issues/157/test-entity.ts
@@ -1,0 +1,24 @@
+import {Attribute, Entity, INDEX_TYPE} from '@typedorm/common';
+const uuid4 = () => '12345678';
+
+@Entity({
+  name: 'sample-entity',
+  primaryKey: {
+    partitionKey: 'en#' + uuid4(),
+    sortKey: 'root',
+  },
+  indexes: {
+    [process.env.EMAIL_INDEX!]: {
+      type: INDEX_TYPE.GSI,
+      partitionKey: '{{email}}',
+      sortKey: '',
+    },
+  },
+})
+export default class EntityData {
+  @Attribute()
+  name!: string;
+
+  @Attribute()
+  email!: string;
+}

--- a/__test__/github-issues/157/test-table.ts
+++ b/__test__/github-issues/157/test-table.ts
@@ -1,0 +1,14 @@
+import {Table, INDEX_TYPE} from '@typedorm/common';
+
+export const testTable = new Table({
+  name: 'user-v2',
+  partitionKey: 'PK',
+  sortKey: 'SK',
+  indexes: {
+    [process.env.EMAIL_INDEX!]: {
+      type: INDEX_TYPE.GSI,
+      partitionKey: 'email',
+      sortKey: 'sk',
+    },
+  },
+});

--- a/packages/core/src/classes/transformer/entity-transformer.ts
+++ b/packages/core/src/classes/transformer/entity-transformer.ts
@@ -70,12 +70,12 @@ export class EntityTransformer extends BaseTransformer {
     // get reflected constructor to avoid initialization issues with custom constructor
     const reflectedConstructor = Reflect.construct(Object, [], entityClass);
 
-    // Perform a deep-copy of item returned by Document client and drop all the custom function types
+    // Perform a deep-copy of item returned by Document client to drop all the custom function types
 
-    // Custom types are emitted by document client in cases where dynamodb item was created outside the js ecosystem.
-    // To correctly deserialize the returned values to relevant Entity, it needs to be in a plain JSON structure.
+    // Custom types are emitted by the document client in cases where dynamodb item was created outside the js ecosystem.
+    // To correctly deserialize the returned values to the relevant Entity, it needs to be in a plain JSON structure.
     // i.e DynamoDB itself supports `StringSet` type but since js doesn't have a `StringSet` as a native type,
-    // Therefore, DocumentClient wraps it as a custom `Set` type which must be turned into it's json form before it can
+    // Therefore, DocumentClient wraps it as a custom `Set` type which must be turned into its JSON form before it can
     // be correctly deserialized by `class-transformer`.
 
     const deserializedEntityAttributes = JSON.parse(

--- a/packages/core/src/classes/transformer/entity-transformer.ts
+++ b/packages/core/src/classes/transformer/entity-transformer.ts
@@ -69,9 +69,22 @@ export class EntityTransformer extends BaseTransformer {
 
     // get reflected constructor to avoid initialization issues with custom constructor
     const reflectedConstructor = Reflect.construct(Object, [], entityClass);
+
+    // Perform a deep-copy of item returned by Document client and drop all the custom function types
+
+    // Custom types are emitted by document client in cases where dynamodb item was created outside the js ecosystem.
+    // To correctly deserialize the returned values to relevant Entity, it needs to be in a plain JSON structure.
+    // i.e DynamoDB itself supports `StringSet` type but since js doesn't have a `StringSet` as a native type,
+    // Therefore, DocumentClient wraps it as a custom `Set` type which must be turned into it's json form before it can
+    // be correctly deserialized by `class-transformer`.
+
+    const deserializedEntityAttributes = JSON.parse(
+      JSON.stringify(plainEntityAttributes)
+    );
+
     const transformedEntity = plainToClassFromExist(
       reflectedConstructor,
-      plainEntityAttributes
+      deserializedEntityAttributes
     );
 
     this.connection.logger.logTransform({


### PR DESCRIPTION
# Changes
 - fixes an issue where trying to deserialize a non-native type in JSON fails with `InvalidSetType` error
 
Custom types are emitted by the document client in cases where Dynamodb item was created outside the js ecosystem.
To correctly deserialize the returned values to the relevant Entity, it needs to be in a plain JSON structure.

i.e DynamoDB itself supports `StringSet` type but since js doesn't have a `StringSet` as a native type,
Therefore, DocumentClient wraps it as a custom `Set` type which must be turned into its JSON form before it can
be correctly deserialized by `class-transformer`.

closes #157 