### PR TITLE
fix(core): correctly detect scalar types

### DIFF
--- a/packages/core/src/helpers/__test__/is-scalar-type.spec.ts
+++ b/packages/core/src/helpers/__test__/is-scalar-type.spec.ts
@@ -1,0 +1,33 @@
+import {isScalarType} from '../is-scalar-type';
+
+test('checks if isScalarType return true for scalar values', () => {
+  const scalarValues = ['string', 1, true, Buffer.from([0])];
+
+  for (const scalarValue of scalarValues) {
+    expect(isScalarType(scalarValue)).toBeTruthy();
+  }
+});
+
+test('checks if isScalarType return true for "empty" scalar values', () => {
+  const scalarValues = ['', 0, false, Buffer.from([])];
+
+  for (const scalarValue of scalarValues) {
+    expect(isScalarType(scalarValue)).toBeTruthy();
+  }
+});
+
+test('checks if isScalarType return false for non-scalar types', () => {
+  const nonScalarValues = [
+    {},
+    [],
+    null,
+    undefined,
+    NaN,
+    new Function(),
+    new Map(),
+  ];
+
+  for (const nonScalarValue of nonScalarValues) {
+    expect(isScalarType(nonScalarValue)).toBeFalsy();
+  }
+});

--- a/packages/core/src/helpers/is-scalar-type.ts
+++ b/packages/core/src/helpers/is-scalar-type.ts
@@ -1,11 +1,10 @@
 import {ScalarType} from '@typedorm/common';
 
 export const isScalarType = (item: any): item is ScalarType =>
-  item &&
-  (typeof item === 'string' ||
-    typeof item === 'number' ||
-    typeof item === 'boolean' ||
-    Buffer.isBuffer(item));
+  typeof item === 'string' ||
+  (typeof item === 'number' && !isNaN(item)) ||
+  typeof item === 'boolean' ||
+  Buffer.isBuffer(item);
 
 export const isScalarTypeProvider = (item: any): item is () => ScalarType =>
   item && typeof item === 'function';


### PR DESCRIPTION
This MR fixes #171

I've decided to remove `item &&` check because it filters valid values such as `false` or `0`.

Added tests.