### PR TITLE
fix: Increase Items per Transaction limit to match AWS limit increase

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Current transaction write items limit set by dynamodb
  */
-export const TRANSACTION_WRITE_ITEMS_LIMIT = 25;
+export const TRANSACTION_WRITE_ITEMS_LIMIT = 100;
 
 /**
  * Current transaction read items limit set by dynamodb


### PR DESCRIPTION
This is bump in a max items per transaction constant to match a [recent limit increase from AWS](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/)!

Fixes #291 