### PR TITLE
Expose Exception types to TypeDORM user

### DIFF
--- a/packages/document-client/public-api.ts
+++ b/packages/document-client/public-api.ts
@@ -7,3 +7,6 @@ export * from './src/classes/base-document-client';
 
 // Types
 export * from './src/types/document-client-types';
+
+// Exceptions
+export * from './src/exceptions';


### PR DESCRIPTION
Sample use-case: 

a put method that implicitly uses transaction due to unique attribute records

```typescript
  async put(user: User): Promise<User> {
    try {
      const userData: TypeDormUser = await this.ormClient.create(user);
      return UserDdbDao.mapTypeDormUserToUser(userData);
    } catch (e) {
      console.error(
        `put user failed ${ JSON.stringify(user) }: `, e
      );

      switch (e.constructor) {
        case TransactionCancelledException:
          const error = (e as TransactionCancelledException);

          if (error.cancellationReasons.length > 0 && error.cancellationReasons[0].code === "ConditionalCheckFailed") {
            throw new ResourceAlreadyExistDataError(
              `User ${ JSON.stringify(user) } already exists`
            );
          }

          throw new InternalDataError(
            JSON.stringify(error.cancellationReasons), e);
        default:
          throw new InternalDataError(`put user failed ${ JSON.stringify(user) }: `, e);
      }
    }
  }

```

Without this:
import looks like this
```
import { TransactionCancelledException } from "@typedorm/document-client/cjs/src/exceptions";

```

Curiously, this only fails for Jest, but `tsc` worked.


