### PR TITLE
remove synthetic default imports

### DIFF
--- a/packages/document-client/src/types/document-client-types.ts
+++ b/packages/document-client/src/types/document-client-types.ts
@@ -1,5 +1,6 @@
-import AWS, {DynamoDB} from 'aws-sdk';
-import DynamoDBClientV3 from '@aws-sdk/client-dynamodb';
+import * as AWS from 'aws-sdk';
+import {DynamoDB} from 'aws-sdk';
+import * as DynamoDBClientV3 from '@aws-sdk/client-dynamodb';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 

--- a/packages/document-client/src/types/gen.document-client-types.ts
+++ b/packages/document-client/src/types/gen.document-client-types.ts
@@ -1,9 +1,10 @@
 import {DocumentClientV2} from '../classes/document-client-v2';
-import AWS, {DynamoDB} from 'aws-sdk';
-import DynamoDBClientV3 from '@aws-sdk/client-dynamodb';
+import * as AWS from 'aws-sdk';
+import {DynamoDB} from 'aws-sdk';
+import * as DynamoDBClientV3 from '@aws-sdk/client-dynamodb';
 
 /**
- * !!important!! Experiment with generics to provider stronger typing
+ * !!important!! Experiment with generics to provide stronger typing
  */
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace DocumentClientTypes {


### PR DESCRIPTION
I don't understand this very well, but I wasn't able to compile my project once I added this package due to these imports. Setting [allowSyntheticDefaultImports](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports) to true in tsconfig works, but that flag seems to be false in most cases. It seems like not using this style of imports would maximize compatibility. What do you think?

```
node_modules/@typedorm/document-client/cjs/src/types/document-client-types.d.ts:1:8 - error TS1192: Module '"node_modules/aws-sdk/index"' has no default export.
1 import AWS, { DynamoDB } from 'aws-sdk';

node_modules/@typedorm/document-client/cjs/src/types/document-client-types.d.ts:2:8 - error TS1192: Module '"node_modules/@aws-sdk/client-dynamodb/dist-types/index"' has no default export.
2 import DynamoDBClientV3 from '@aws-sdk/client-dynamodb';
```