### PR TITLE
Allow `EntityManager.create` to infer `EntityInstance` type

### DIFF
--- a/packages/core/src/classes/manager/__test__/entity-manager.spec.ts
+++ b/packages/core/src/classes/manager/__test__/entity-manager.spec.ts
@@ -213,6 +213,30 @@ test('creates entity and returns all attributes, including auto generated ones',
   });
 });
 
+test('will infer the proper return type when creating an entity', async () => {
+  dcMock.put.mockReturnValue({
+    promise: () => ({}),
+  });
+
+  const user = new User();
+  user.id = '1';
+  user.name = 'Test User';
+  user.status = 'active';
+
+  const ret = await manager.create(user);
+
+  type Expect<T extends true> = T;
+  type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+    ? 1
+    : 2
+    ? true
+    : false;
+
+  // would fail to compile if the types did not match
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type Assert = Expect<Equal<typeof ret, User>>;
+});
+
 /**
  * Issue: #203
  */
@@ -236,9 +260,9 @@ test('will throw when called with a POJO rather than an instance of a entity cla
     addresses: ['address a'],
   };
 
-  await expect(
-    manager.create<User>(userProperties as EntityInstance)
-  ).rejects.toBeInstanceOf(Error);
+  await expect(manager.create<User>(userProperties)).rejects.toBeInstanceOf(
+    Error
+  );
 });
 
 /**

--- a/packages/core/src/classes/manager/__test__/entity-manager.spec.ts
+++ b/packages/core/src/classes/manager/__test__/entity-manager.spec.ts
@@ -14,7 +14,6 @@ import {
 import {Connection} from '../../connection/connection';
 import {
   CONSUMED_CAPACITY_TYPE,
-  EntityInstance,
   InvalidDynamicUpdateAttributeValueError,
 } from '@typedorm/common';
 import {

--- a/packages/core/src/classes/manager/entity-manager.ts
+++ b/packages/core/src/classes/manager/entity-manager.ts
@@ -190,11 +190,11 @@ export class EntityManager {
    * Creates new record in table with given entity
    * @param entity Entity to add to table as a new record
    */
-  async create<Entity>(
-    entity: EntityInstance,
-    options?: EntityManagerCreateOptions<Entity>,
+  async create<TEntity extends EntityInstance>(
+    entity: TEntity,
+    options?: EntityManagerCreateOptions<TEntity>,
     metadataOptions?: MetadataOptions
-  ): Promise<Entity> {
+  ): Promise<TEntity> {
     if (!IsEntityInstance(entity)) {
       throw new Error(
         `Provided entity ${JSON.stringify(
@@ -231,7 +231,7 @@ export class EntityManager {
       }
 
       // by default dynamodb does not return attributes on create operation, so return one
-      const itemToReturn = this._entityTransformer.fromDynamoEntity<Entity>(
+      const itemToReturn = this._entityTransformer.fromDynamoEntity<TEntity>(
         entityClass,
         dynamoPutItemInput.Item as DocumentClientTypes.AttributeMap,
         {
@@ -250,7 +250,7 @@ export class EntityManager {
       returnConsumedCapacity: metadataOptions?.returnConsumedCapacity,
     });
 
-    const itemToReturn = this._entityTransformer.fromDynamoEntity<Entity>(
+    const itemToReturn = this._entityTransformer.fromDynamoEntity<TEntity>(
       entityClass,
       // if create operation contains multiple items, first one will the original item
       dynamoPutItemInput[0]?.Put?.Item ?? {},


### PR DESCRIPTION
Hi folks - I wanted to be able to omit the `Entity` type parameter on `EntityManager.create`, since I believe it can be inferred without issue. This PR attempts to allow just that.

Previously:
```
const user = new User();
user.id = '1';
user.name = 'Test User';
user.status = 'active';

const ret = await manager.create(user);
// ^? const ret: unknown

```

Now:
```
const user = new User();
user.id = '1';
user.name = 'Test User';
user.status = 'active';

const ret = await manager.create(user);
// ^? const ret: User
```

Please let me know what you think, and thanks for your hard work!