### PR TITLE
fix: class-transformer as peer dependency

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,8 @@
     "orm"
   ],
   "peerDependencies": {
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "class-transformer": "*"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
     "@typedorm/common": "0.0.0-PLACEHOLDER",
     "reflect-metadata": "^0.1.13",
     "aws-sdk": "^2.799.0",
-    "@aws-sdk/client-dynamodb": "^3.31.0"
+    "@aws-sdk/client-dynamodb": "^3.31.0",
+    "class-transformer": "*"
   },
   "dependencies": {
     "uuid": "^8.3.1",


### PR DESCRIPTION
Marks class-transformer as peer dependency next to dependency. This ensures consumer installed version is prioritized and used to avoid runtime issues.

Resolves: #341, #365 