### PR TITLE
docs: fix typos in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ export class Organisation {
   active: boolean;
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true, // this will make this attribute and any indexes referencing it auto update for any write operation
   })
   updatedAt: number;

--- a/docs/entity-inheritance.md
+++ b/docs/entity-inheritance.md
@@ -32,7 +32,7 @@ export class Admin {
   department: string
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true
   })
   updatedAt: string
@@ -61,7 +61,7 @@ export class Student {
   studentId: number
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true
   })
   updatedAt: string
@@ -87,7 +87,7 @@ export class Parent {
   name: string;
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true
   })
   updatedAt: string
@@ -107,7 +107,7 @@ export abstract class User {
   name: string;
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true
   })
   updatedAt: string

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -101,7 +101,7 @@ Now, TypeDORM knows about all indexes, keys and how it needs to be structured, b
 To add attributes to entity, use `@Attribute` or other higher level annotations like `@AutoGenerateAttribute`.
 
 ```Typescript
-import {Table} from '@typedorm/common';
+import {Entity, INDEX_TYPE, Attribute} from '@typedorm/common';
 
 @Entity({
   name: 'user', // name of the entity that will be added to each item as an attribute
@@ -131,9 +131,9 @@ export class User {
   email: string;
 
   @Attribute()
-  status: string
+  status: string;
 
-  updatedAt: string
+  updatedAt: string;
 }
 ```
 
@@ -342,7 +342,7 @@ To get more insight on how how update works with TypeDORM, have a look at [this]
 Going ahead with earlier example of `User` entity, let's each of our user can have many orders, and our order entity looks like this
 
 ```Typescript
-import {Attribute, Entity, AutoGenerateAttribute} from '@typedorm/common';
+import {Attribute, Entity, AutoGenerateAttribute, INDEX_TYPE} from '@typedorm/common';
 import {AUTO_GENERATE_ATTRIBUTE_STRATEGY} from '@typedorm/common';
 
 @Entity({

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -181,7 +181,7 @@ export class User {
   status: string
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
     autoUpdate: true
   })
   updatedAt: string
@@ -376,7 +376,7 @@ export class Order {
   status: string
 
   @AutoGenerateAttribute({
-    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH,
+    strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE,
   })
   createdAt: string
 }


### PR DESCRIPTION
I have corrected a few errors in the TypeScript documentation as follows:
- Changed the attribute AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH to AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE.
- Fixed an invalid import statement in guide.md.