### PR TITLE
fix: scan manager scan limit should reset each invocation

### DIFF
--- a/packages/core/src/classes/manager/scan-manager.ts
+++ b/packages/core/src/classes/manager/scan-manager.ts
@@ -343,7 +343,7 @@ export class ScanManager {
 
     const allPromisesResponse = await Promise.all(
       parallelScanOptions.map(options =>
-        this.toLimited(this.scan<Entity>(options, metadataOptions))
+        this.toLimited(this._scan<Entity>(options, metadataOptions))
       )
     );
 
@@ -410,7 +410,26 @@ export class ScanManager {
   }> {
     // start with 0
     this.itemsFetchedSoFarTotalParallelCount = 0;
+    return this._scan(scanOptions, metadataOptions);
+  }
 
+  /**
+   * Internal implementation of scan.
+   * In all external use-cases scan should be used
+   * This implementation does not reset `itemsFetchedSoFarTotalParallelCount` as it is called from parallelScan
+   * @param {ScanManagerScanOptions} scanOptions
+   * @param {MetadataOptions} metadataOptions
+   * @returns {Promise<{items: Entity[] | undefined, unknownItems: DocumentClientTypes.AttributeMap[] | undefined, cursor: DocumentClientTypes.Key | undefined}>}
+   * @internal
+   */
+  protected async _scan<Entity>(
+    scanOptions?: ScanManagerScanOptions,
+    metadataOptions?: MetadataOptions
+  ): Promise<{
+    items: Entity[] | undefined;
+    unknownItems: DocumentClientTypes.AttributeMap[] | undefined;
+    cursor: DocumentClientTypes.Key | undefined;
+  }> {
     const requestId = getUniqueRequestId(metadataOptions?.requestId);
 
     const dynamoScanInput = this._dcScanTransformer.toDynamoScanItem(

--- a/packages/core/src/classes/manager/scan-manager.ts
+++ b/packages/core/src/classes/manager/scan-manager.ts
@@ -408,6 +408,9 @@ export class ScanManager {
     unknownItems: DocumentClientTypes.AttributeMap[] | undefined;
     cursor: DocumentClientTypes.Key | undefined;
   }> {
+    // start with 0
+    this.itemsFetchedSoFarTotalParallelCount = 0;
+
     const requestId = getUniqueRequestId(metadataOptions?.requestId);
 
     const dynamoScanInput = this._dcScanTransformer.toDynamoScanItem(


### PR DESCRIPTION
There is currently a bug in scan manager. When running a scan or find operation *without* `totalSegments` and *with* `limit` in the ScanOptions, the `itemsFetchedSoFarTotalParallelCount` variable is updated with the number of items scanned but is not reset to 0.

**This results in no items being scanned in subsequent calls to the scan (or find) method.**
Example: 
```typescript
getScanManager().find(SomeEntity, {limit: 1}); // Succeeds

getScanManager().find(SomeEntity, {limit: 1}); // Returns { items: [] }, even with remaining items to scan in the table

Object.assign(getScanManager(), {itemsFetchedSoFarTotalParallelCount: 0}); // Temporary fix

getScanManager().find(SomeEntity, {limit: 1}); // Succeeds
```




The existing implementation of `parallelScan` correctly starts by setting the variable to 0 while the implementation of `scan` does not: 
```typescript
 // start with 0
 this.itemsFetchedSoFarTotalParallelCount = 0;

...

 const allPromisesResponse = await Promise.all(
      parallelScanOptions.map(options =>
        this.toLimited(this.scan<Entity>(options, metadataOptions))
      )
    );
```
`this.scan` is called (multiple times) from within `parallelScan`, thus we can't just add a `this.itemsFetchedSoFarTotalParallelCount = 0;` at the start of `scan`, rather I migrated the existing `scan` method to an internal `_scan` method. The new `_scan` method is unchanged from the original `scan` method, and the updated (public) `scan` method calls `this.itemsFetchedSoFarTotalParallelCount = 0;` followed by calling `_scan`. 

This leaves the `parallelScan` working as it currently does, and fixes the issue when using the normal `scan` method. 

(First time contributing here, thank you so much for the awesome library! Let me know if any changes are needed to get this pr approved. Thanks!)