### PR TITLE
feat: add WriteBatch addPutItem support

### DIFF
--- a/packages/core/src/classes/batch/type-guards.ts
+++ b/packages/core/src/classes/batch/type-guards.ts
@@ -1,10 +1,16 @@
 import {isEmptyObject} from '@typedorm/common';
-import {WriteBatchCreate, WriteBatchDelete} from './write-batch';
+import {WriteBatchCreate, WriteBatchPut, WriteBatchDelete} from './write-batch';
 
 export function isBatchAddCreateItem<Entity>(
   item: any
 ): item is WriteBatchCreate<Entity> {
   return !isEmptyObject(item) && !!(item as WriteBatchCreate<Entity>).create;
+}
+
+export function isBatchAddPutItem<Entity>(
+  item: any
+): item is WriteBatchPut<Entity> {
+  return !isEmptyObject(item) && !!(item as WriteBatchPut<Entity>).put;
 }
 
 export function isBatchAddDeleteItem<Entity, PrimaryKey>(

--- a/packages/core/src/classes/batch/write-batch.ts
+++ b/packages/core/src/classes/batch/write-batch.ts
@@ -7,6 +7,12 @@ export interface WriteBatchCreate<Entity> {
   };
 }
 
+export interface WriteBatchPut<Entity> {
+  put: {
+    item: Entity;
+  };
+}
+
 export interface WriteBatchDelete<Entity, PrimaryKey> {
   delete: {
     item: EntityTarget<Entity>;
@@ -16,6 +22,7 @@ export interface WriteBatchDelete<Entity, PrimaryKey> {
 
 export type WriteBatchItem<Entity, PrimaryKey> =
   | WriteBatchCreate<Entity>
+  | WriteBatchPut<Entity>
   | WriteBatchDelete<Entity, PrimaryKey>;
 
 export class WriteBatch extends Batch<WriteBatchItem<any, any>> {
@@ -27,6 +34,15 @@ export class WriteBatch extends Batch<WriteBatchItem<any, any>> {
   addCreateItem<Entity>(item: Entity): this {
     this.items.push({
       create: {
+        item,
+      },
+    });
+    return this;
+  }
+
+  addPutItem<Entity>(item: Entity): this {
+    this.items.push({
+      put: {
         item,
       },
     });

--- a/packages/core/src/classes/transformer/document-client-batch-transformer.ts
+++ b/packages/core/src/classes/transformer/document-client-batch-transformer.ts
@@ -8,7 +8,11 @@ import {
 import {v4} from 'uuid';
 import {getHashedIdForInput} from '../../helpers/get-hashed-id-for-input';
 import {ReadBatch, ReadBatchItem} from '../batch/read-batch';
-import {isBatchAddCreateItem, isBatchAddDeleteItem} from '../batch/type-guards';
+import {
+  isBatchAddCreateItem,
+  isBatchAddDeleteItem,
+  isBatchAddPutItem,
+} from '../batch/type-guards';
 import {WriteBatchItem, WriteBatch} from '../batch/write-batch';
 import {Connection} from '../connection/connection';
 import {isWriteTransactionItemList} from '../transaction/type-guards';
@@ -299,12 +303,12 @@ export class DocumentClientBatchTransformer extends LowOrderTransformers {
 
     return batchItems.reduce(
       (acc, batchItem) => {
-        // is create
-        if (isBatchAddCreateItem(batchItem)) {
+        // is create or put
+        if (isBatchAddCreateItem(batchItem) || isBatchAddPutItem(batchItem)) {
           // transform put item
           const dynamoPutItem = this.toDynamoPutItem(
-            batchItem.create.item,
-            undefined,
+            'create' in batchItem ? batchItem.create.item : batchItem.put.item,
+            {overwriteIfExists: isBatchAddPutItem(batchItem)},
             metadataOptions
           );
           if (!isWriteTransactionItemList(dynamoPutItem)) {


### PR DESCRIPTION
# Motivations

I was looking to do a batch write where one of my items just needed to be a PUT since it's under a job that runs continuously, so the item might already be present, and if it is, it's fine to override it. 

I had done it with `patch-package`, but it was simple enough that it was worth a PR.