### PR TITLE
Update auto-generate-attribute-value.ts to include EPOCH_MILLIS

### DIFF
--- a/packages/core/src/helpers/auto-generate-attribute-value.ts
+++ b/packages/core/src/helpers/auto-generate-attribute-value.ts
@@ -25,6 +25,12 @@ export class AutoGenerateAttributeValue {
       AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_DATE
     ) as number;
   }
+
+  static get EPOCH_MILLIS() {
+    return autoGenerateValue(
+      AUTO_GENERATE_ATTRIBUTE_STRATEGY.EPOCH_MILLIS
+    ) as number;
+  }
 }
 
 export function autoGenerateValue(strategy: AUTO_GENERATE_ATTRIBUTE_STRATEGY) {


### PR DESCRIPTION
It looks like EPOCH_MILLIS was anticipated, but not fully integrated? I need access to milliseconds so I don't need to multiply all timestamps received from the backend by 1000 when converting and using javascript Date function.